### PR TITLE
feat: luarocks support

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,34 @@
+name: Push to Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+  pull_request: # Makes sure the luarocks package can build on PR
+  workflow_dispatch: # Allow manual trigger (e.g. if a tagged build failed)
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            plenary.nvim
+            nui.nvim
+            reactivex
+          labels: |
+            neovim
+          summary: "Docker management right inside Neovim!"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+        with:
+          release-type: simple
+          package-name: nvim-docker

--- a/README.md
+++ b/README.md
@@ -22,13 +22,27 @@ Docker management right inside Neovim!
   
 ## Installation
 
-### Packer
+### Using [`rocks.nvim`](https://github.com/nvim-neorocks/rocks.nvim)
+
+```vimscript
+:Rocks install nvim-docker
+```
+
+### [`lazy.nvim`](https://github.com/folke/lazy.nvim)
 
 ```lua
-use {
+{
   'dgrbrady/nvim-docker',
-  requires = {'nvim-lua/plenary.nvim', 'MunifTanjim/nui.nvim'},
-  rocks = '4O4/reactivex' -- ReactiveX Lua implementation
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+    'MunifTanjim/nui.nvim',
+    { 
+      '4O4/reactivex',
+      build = function(plugin)
+        vim.uv.fs_symlink(plugin.dir, plugin.dir .. "/lua", { dir = true })
+      end,
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
Hey :wave: 

I noticed this plugin has some dependencies that are on luarocks...


### Summary

This PR is part of a push to get neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.
* See also: [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.

### Things done:

* Add a release-please workflow that creates release PRs with SemVer versioning based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* Add a workflow that publishes tags to LuaRocks when a tag or release is pushed.

The workflows are based on [this guide](https://github.com/vhyrro/sample-luarocks-plugin) by @vhyrro.

### Notes:

* On each merge to `main`, the `release-please` workflow creates (or updates an existing) release PR.
* You decide when to merge release PRs.
  Doing so will result in a SemVer tag, and a GitHub release, which will trigger the `luarocks` workflow.
* Tagged releases are installed locally and then published to luarocks.org.
  On PRs, a test release is installed, but not published.
* For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.